### PR TITLE
Fix: EventRequestParserTest

### DIFF
--- a/tests/LINEBot/EventRequestParserTest.php
+++ b/tests/LINEBot/EventRequestParserTest.php
@@ -1357,7 +1357,7 @@ JSON;
                 $event->getWebhookEventId()
             );
             $this->assertInstanceOf('LINE\LINEBot\Event\VideoPlayCompleteEvent', $event);
-            /** @var UnsendMessage $event */
+            /** @var VideoPlayCompleteEvent $event */
             $this->assertEquals('track_id', $event->getTrackingId());
         }
 


### PR DESCRIPTION
# Overview
The type comment of the variable in the "VideoPlayCompleteEvent" test in the test code "EventRequestParserTest" is wrong.
This has no particular impact on the library implementation itself, but because I noticed it.