### PR TITLE
'CURLOPT_BINARYTRANSFER' is deprecated.

### DIFF
--- a/src/LINEBot/HTTPClient/CurlHTTPClient.php
+++ b/src/LINEBot/HTTPClient/CurlHTTPClient.php
@@ -146,7 +146,6 @@ class CurlHTTPClient implements HTTPClient
             CURLOPT_CUSTOMREQUEST => $method,
             CURLOPT_HTTPHEADER => $headers,
             CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_BINARYTRANSFER => true,
             CURLOPT_HEADER => true,
         ];
         if ($method === 'POST') {


### PR DESCRIPTION
# Overview
`CURLOPT_BINARYTRANSFER` is not required in PHP 5.1.3 and later, and should be removed.

This part is warned by the VSCode extension "intelephense".

<img width="589" alt="image" src="https://user-images.githubusercontent.com/49806926/167992560-680223b3-b92d-49f7-beef-8c06d93da917.png">


## Reference
There is no `CURLOPT_BINARYTRANSFER` in the `curl` options in the official php documentation.
https://www.php.net/manual/en/function.curl-setopt.php

The following explanation is given in the web archive here.
https://php-legacy-docs.zend.com/manual/php5/en/function.curl-setopt

CURLOPT_BINARYTRANSFER | TRUE to return the raw output when CURLOPT_RETURNTRANSFER is used. | From PHP 5.1.3, this option has no effect: the raw output will always be returned when CURLOPT_RETURNTRANSFER is used.
-- | -- | --