### PR TITLE
Add two optional properties to PostbackTemplateActionBuilder

### DIFF
--- a/src/LINEBot/Constant/PostbackInputOption.php
+++ b/src/LINEBot/Constant/PostbackInputOption.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace LINE\LINEBot\Constant;
+
+class PostbackInputOption
+{
+    const CLOSE_RICH_MENU = 'closeRichMenu';
+    const OPEN_RICH_MENU = 'openRichMenu';
+    const OPEN_KEYBOARD = 'openKeyboard';
+    const OPEN_VOICE = 'openVoice';
+}

--- a/src/LINEBot/TemplateActionBuilder/PostbackTemplateActionBuilder.php
+++ b/src/LINEBot/TemplateActionBuilder/PostbackTemplateActionBuilder.php
@@ -34,6 +34,10 @@ class PostbackTemplateActionBuilder implements TemplateActionBuilder
     private $data;
     /** @var string|null */
     private $displayText;
+    /** @var string|null */
+    private $inputOption;
+    /** @var string|null */
+    private $fillInText;
 
     /**
      * PostbackAction constructor.
@@ -41,12 +45,16 @@ class PostbackTemplateActionBuilder implements TemplateActionBuilder
      * @param string $label Label of action.
      * @param string $data Data of postback.
      * @param string|null $displayText The text which will be sent when action is executed (optional).
+     * @param string|null $inputOption The display method of such as rich menu based on user action (optional).
+     * @param string|null $fillInText String to be pre-filled in the input field when the keyboard is opened (optional).
      */
-    public function __construct($label, $data, $displayText = null)
+    public function __construct($label, $data, $displayText = null, $inputOption = null, $fillInText = null)
     {
         $this->label = $label;
         $this->data = $data;
         $this->displayText = $displayText;
+        $this->inputOption = $inputOption;
+        $this->fillInText = $fillInText;
     }
 
     /**
@@ -65,6 +73,16 @@ class PostbackTemplateActionBuilder implements TemplateActionBuilder
         if (isset($this->displayText)) {
             // If text is set, append extend field.
             $action['displayText'] = $this->displayText;
+        }
+
+        if (isset($this->inputOption)) {
+            // If inputOption is set, append extend field.
+            $action['inputOption'] = $this->inputOption;
+        }
+
+        if (isset($this->fillInText)) {
+            // If fillInText is set, append extend field.
+            $action['fillInText'] = $this->fillInText;
         }
 
         return $action;

--- a/tests/LINEBot/SendTemplateTest.php
+++ b/tests/LINEBot/SendTemplateTest.php
@@ -21,6 +21,7 @@ namespace LINE\Tests\LINEBot;
 use LINE\LINEBot;
 use LINE\LINEBot\Constant\ActionType;
 use LINE\LINEBot\Constant\MessageType;
+use LINE\LINEBot\Constant\PostbackInputOption;
 use LINE\LINEBot\Constant\TemplateType;
 use LINE\LINEBot\MessageBuilder\TemplateBuilder\ButtonTemplateBuilder;
 use LINE\LINEBot\MessageBuilder\TemplateBuilder\ImageCarouselTemplateBuilder;
@@ -56,7 +57,7 @@ class SendTemplateTest extends TestCase
             $testRunner->assertEquals('https://example.com/thumbnail.jpg', $template['thumbnailImageUrl']);
 
             $actions = $template['actions'];
-            $testRunner->assertEquals(3, count($actions));
+            $testRunner->assertEquals(5, count($actions));
             $testRunner->assertEquals(ActionType::POSTBACK, $actions[0]['type']);
             $testRunner->assertEquals('postback label', $actions[0]['label']);
             $testRunner->assertEquals('post=back', $actions[0]['data']);
@@ -74,6 +75,19 @@ class SendTemplateTest extends TestCase
                     $actions[2]['altUri']
                 );
             }
+
+            $testRunner->assertEquals(ActionType::POSTBACK, $actions[3]['type']);
+            $testRunner->assertEquals('postback label2', $actions[3]['label']);
+            $testRunner->assertEquals('post=back2', $actions[3]['data']);
+            $testRunner->assertEquals('extend text', $actions[3]['displayText']);
+            $testRunner->assertEquals('openKeyboard', $actions[3]['inputOption']);
+
+            $testRunner->assertEquals(ActionType::POSTBACK, $actions[4]['type']);
+            $testRunner->assertEquals('postback label3', $actions[4]['label']);
+            $testRunner->assertEquals('post=back3', $actions[4]['data']);
+            $testRunner->assertEquals('extend text2', $actions[4]['displayText']);
+            $testRunner->assertEquals('openKeyboard', $actions[4]['inputOption']);
+            $testRunner->assertEquals('fill in text', $actions[4]['fillInText']);
 
             return ['status' => 200];
         };
@@ -95,6 +109,19 @@ class SendTemplateTest extends TestCase
                             'uri label',
                             'https://example.com',
                             new AltUriBuilder('http://example.com/pc/page/222')
+                        ),
+                        new PostbackTemplateActionBuilder(
+                            'postback label2',
+                            'post=back2',
+                            'extend text',
+                            PostbackInputOption::OPEN_KEYBOARD
+                        ),
+                        new PostbackTemplateActionBuilder(
+                            'postback label3',
+                            'post=back3',
+                            'extend text2',
+                            PostbackInputOption::OPEN_KEYBOARD,
+                            'fill in text'
                         ),
                     ]
                 )
@@ -118,6 +145,19 @@ class SendTemplateTest extends TestCase
                         new PostbackTemplateActionBuilder('postback label', 'post=back'),
                         new MessageTemplateActionBuilder('message label', 'test message'),
                         new UriTemplateActionBuilder('uri label', 'https://example.com'),
+                        new PostbackTemplateActionBuilder(
+                            'postback label2',
+                            'post=back2',
+                            'extend text',
+                            PostbackInputOption::OPEN_KEYBOARD
+                        ),
+                        new PostbackTemplateActionBuilder(
+                            'postback label3',
+                            'post=back3',
+                            'extend text2',
+                            PostbackInputOption::OPEN_KEYBOARD,
+                            'fill in text'
+                        ),
                     ]
                 )
             )
@@ -149,7 +189,7 @@ class SendTemplateTest extends TestCase
             $testRunner->assertEquals('https://example.com/thumbnail.jpg', $template['thumbnailImageUrl']);
 
             $actions = $template['actions'];
-            $testRunner->assertEquals(4, count($actions));
+            $testRunner->assertEquals(6, count($actions));
             $testRunner->assertEquals(ActionType::POSTBACK, $actions[0]['type']);
             $testRunner->assertEquals('postback label', $actions[0]['label']);
             $testRunner->assertEquals('post=back', $actions[0]['data']);
@@ -171,6 +211,19 @@ class SendTemplateTest extends TestCase
                     $actions[3]['altUri']
                 );
             }
+
+            $testRunner->assertEquals(ActionType::POSTBACK, $actions[4]['type']);
+            $testRunner->assertEquals('postback label3', $actions[4]['label']);
+            $testRunner->assertEquals('post=back3', $actions[4]['data']);
+            $testRunner->assertEquals('extend text2', $actions[4]['displayText']);
+            $testRunner->assertEquals('openKeyboard', $actions[4]['inputOption']);
+
+            $testRunner->assertEquals(ActionType::POSTBACK, $actions[5]['type']);
+            $testRunner->assertEquals('postback label4', $actions[5]['label']);
+            $testRunner->assertEquals('post=back4', $actions[5]['data']);
+            $testRunner->assertEquals('extend text3', $actions[5]['displayText']);
+            $testRunner->assertEquals('openKeyboard', $actions[5]['inputOption']);
+            $testRunner->assertEquals('fill in text', $actions[5]['fillInText']);
 
             $testRunner->assertEquals('rectangle', $template['imageAspectRatio']);
             $testRunner->assertEquals('cover', $template['imageSize']);
@@ -198,6 +251,19 @@ class SendTemplateTest extends TestCase
                             'https://example.com',
                             new AltUriBuilder('http://example.com/pc/page/222')
                         ),
+                        new PostbackTemplateActionBuilder(
+                            'postback label3',
+                            'post=back3',
+                            'extend text2',
+                            PostbackInputOption::OPEN_KEYBOARD
+                        ),
+                        new PostbackTemplateActionBuilder(
+                            'postback label4',
+                            'post=back4',
+                            'extend text3',
+                            PostbackInputOption::OPEN_KEYBOARD,
+                            'fill in text'
+                        ),
                     ],
                     'rectangle',
                     'cover',
@@ -224,6 +290,20 @@ class SendTemplateTest extends TestCase
                         new PostbackTemplateActionBuilder('postback label2', 'post=back2', 'extend text'),
                         new MessageTemplateActionBuilder('message label', 'test message'),
                         new UriTemplateActionBuilder('uri label', 'https://example.com'),
+
+                        new PostbackTemplateActionBuilder(
+                            'postback label3',
+                            'post=back3',
+                            'extend text2',
+                            PostbackInputOption::OPEN_KEYBOARD
+                        ),
+                        new PostbackTemplateActionBuilder(
+                            'postback label4',
+                            'post=back4',
+                            'extend text3',
+                            PostbackInputOption::OPEN_KEYBOARD,
+                            'fill in text'
+                        ),
                     ],
                     'rectangle',
                     'cover',

--- a/tests/LINEBot/TemplateActionBuilder/PostbackTemplateActionBuilderTest.php
+++ b/tests/LINEBot/TemplateActionBuilder/PostbackTemplateActionBuilderTest.php
@@ -28,7 +28,7 @@ class PostbackTemplateActionBuilderTest extends TestCase
     {
         $poskbackTemplateAction = new PostbackTemplateActionBuilder(
             'postback label',
-            'post=back',
+            'post=back'
         );
 
         $this->assertEquals(
@@ -46,7 +46,7 @@ class PostbackTemplateActionBuilderTest extends TestCase
         $poskbackTemplateAction = new PostbackTemplateActionBuilder(
             'postback label',
             'post=back',
-            'extend text',
+            'extend text'
         );
 
         $this->assertEquals(
@@ -67,7 +67,7 @@ class PostbackTemplateActionBuilderTest extends TestCase
             'postback label',
             'post=back',
             'extend text',
-            PostbackInputOption::CLOSE_RICH_MENU,
+            PostbackInputOption::CLOSE_RICH_MENU
         );
 
         $this->assertEquals(
@@ -86,7 +86,7 @@ class PostbackTemplateActionBuilderTest extends TestCase
             'postback label2',
             'post=back2',
             'extend text2',
-            PostbackInputOption::OPEN_RICH_MENU,
+            PostbackInputOption::OPEN_RICH_MENU
         );
 
         $this->assertEquals(
@@ -105,7 +105,7 @@ class PostbackTemplateActionBuilderTest extends TestCase
             'postback label3',
             'post=back3',
             'extend text3',
-            PostbackInputOption::OPEN_KEYBOARD,
+            PostbackInputOption::OPEN_KEYBOARD
         );
 
         $this->assertEquals(
@@ -124,7 +124,7 @@ class PostbackTemplateActionBuilderTest extends TestCase
             'postback label4',
             'post=back4',
             'extend text4',
-            PostbackInputOption::OPEN_VOICE,
+            PostbackInputOption::OPEN_VOICE
         );
 
         $this->assertEquals(
@@ -147,7 +147,7 @@ class PostbackTemplateActionBuilderTest extends TestCase
             'post=back',
             'extend text',
             PostbackInputOption::OPEN_KEYBOARD,
-            'fill in text',
+            'fill in text'
         );
 
         $this->assertEquals(

--- a/tests/LINEBot/TemplateActionBuilder/PostbackTemplateActionBuilderTest.php
+++ b/tests/LINEBot/TemplateActionBuilder/PostbackTemplateActionBuilderTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at=>
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace LINE\Tests\LINEBot;
+
+use LINE\LINEBot\Constant\PostbackInputOption;
+use LINE\LINEBot\TemplateActionBuilder\PostbackTemplateActionBuilder;
+use PHPUnit\Framework\TestCase;
+
+class PostbackTemplateActionBuilderTest extends TestCase
+{
+    public function testLabelAndData()
+    {
+        $poskbackTemplateAction = new PostbackTemplateActionBuilder(
+            'postback label',
+            'post=back',
+        );
+
+        $this->assertEquals(
+            [
+                "type" => "postback",
+                "label" => "postback label",
+                "data" => "post=back",
+            ],
+            $poskbackTemplateAction->buildTemplateAction()
+        );
+    }
+
+    public function testDisplayText()
+    {
+        $poskbackTemplateAction = new PostbackTemplateActionBuilder(
+            'postback label',
+            'post=back',
+            'extend text',
+        );
+
+        $this->assertEquals(
+            [
+                "type" => "postback",
+                "label" => "postback label",
+                "data" => "post=back",
+                "displayText" => "extend text",
+            ],
+            $poskbackTemplateAction->buildTemplateAction()
+        );
+    }
+
+    public function testInputOption()
+    {
+        // Case where inputOption parameter is "closeRichMenu"
+        $poskbackTemplateAction = new PostbackTemplateActionBuilder(
+            'postback label',
+            'post=back',
+            'extend text',
+            PostbackInputOption::CLOSE_RICH_MENU,
+        );
+
+        $this->assertEquals(
+            [
+                "type" => "postback",
+                "label" => "postback label",
+                "data" => "post=back",
+                "displayText" => "extend text",
+                "inputOption" => "closeRichMenu",
+            ],
+            $poskbackTemplateAction->buildTemplateAction()
+        );
+
+        // Case where inputOption parameter is "openRichMenu"
+        $poskbackTemplateAction2 = new PostbackTemplateActionBuilder(
+            'postback label2',
+            'post=back2',
+            'extend text2',
+            PostbackInputOption::OPEN_RICH_MENU,
+        );
+
+        $this->assertEquals(
+            [
+                "type" => "postback",
+                "label" => "postback label2",
+                "data" => "post=back2",
+                "displayText" => "extend text2",
+                "inputOption" => "openRichMenu",
+            ],
+            $poskbackTemplateAction2->buildTemplateAction()
+        );
+
+        // Case where inputOption parameter is "openKeyBoard"
+        $poskbackTemplateAction3 = new PostbackTemplateActionBuilder(
+            'postback label3',
+            'post=back3',
+            'extend text3',
+            PostbackInputOption::OPEN_KEYBOARD,
+        );
+
+        $this->assertEquals(
+            [
+                "type" => "postback",
+                "label" => "postback label3",
+                "data" => "post=back3",
+                "displayText" => "extend text3",
+                "inputOption" => "openKeyboard",
+            ],
+            $poskbackTemplateAction3->buildTemplateAction()
+        );
+
+        // Case where inputOption parameter is "openVoice"
+        $poskbackTemplateAction4 = new PostbackTemplateActionBuilder(
+            'postback label4',
+            'post=back4',
+            'extend text4',
+            PostbackInputOption::OPEN_VOICE,
+        );
+
+        $this->assertEquals(
+            [
+                "type" => "postback",
+                "label" => "postback label4",
+                "data" => "post=back4",
+                "displayText" => "extend text4",
+                "inputOption" => "openVoice",
+            ],
+            $poskbackTemplateAction4->buildTemplateAction()
+        );
+    }
+
+
+    public function testFillInText()
+    {
+        $poskbackTemplateAction = new PostbackTemplateActionBuilder(
+            'postback label',
+            'post=back',
+            'extend text',
+            PostbackInputOption::OPEN_KEYBOARD,
+            'fill in text',
+        );
+
+        $this->assertEquals(
+            [
+                "type" => "postback",
+                "label" => "postback label",
+                "data" => "post=back",
+                "displayText" => "extend text",
+                "inputOption" => "openKeyboard",
+                "fillInText" => "fill in text",
+            ],
+            $poskbackTemplateAction->buildTemplateAction()
+        );
+    }
+}

--- a/tests/LINEBot/TemplateActionBuilder/PostbackTemplateActionBuilderTest.php
+++ b/tests/LINEBot/TemplateActionBuilder/PostbackTemplateActionBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2020 LINE Corporation
+ * Copyright 2022 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance


### PR DESCRIPTION
# Overview
On May 13th, a function to open and close the rich menu automatically when you tap the rich menu, etc. were added.

## Related issue
- 

## Reference
https://developers.line.biz/en/news/2022/05/13/richmenu-keyboard/

## Test
```php
$templateMessage = new TemplateMessageBuilder(
    'タイトル',
    new ButtonTemplateBuilder(
        'タイトル',
        'テキスト',
        '',
        [
            new PostbackTemplateActionBuilder('keyboard', 'button=1', null, PostbackInputOption::OPEN_KEYBOARD),
            new PostbackTemplateActionBuilder(
                'keyboard with text',
                'button=0',
                null,
                PostbackInputOption::OPEN_KEYBOARD,
                'text'
            ),
        ]
    )
);
$bot->replyMessage($replyToken, $templateMessage);
```

<img src="https://user-images.githubusercontent.com/49806926/168415244-8fea1daf-8700-43b1-8945-2307b8344f5d.jpg" width="400">
